### PR TITLE
Use forked Hugo theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "themes/PaperMod"]
 	path = themes/PaperMod
-	url = https://github.com/adityatelange/hugo-PaperMod.git
+	url = https://github.com/acikgozb/hugo-PaperMod.git


### PR DESCRIPTION
I've updated the default Linkedin logo of PaperMod theme by creating a fork.
Since the theme is used as a submodule, I've updated the submodule url to point to the fork instead.