### PR TITLE
Remove the draft flags from initial content

### DIFF
--- a/content/about/index.md
+++ b/content/about/index.md
@@ -8,30 +8,30 @@ title: "About"
 
 Hello again 👋
 
-I'm a self-taught Software Engineer since May 2019 who decided to give web development a try and started from absolute zero with nothing but HTML.
+I'm a self-taught Software Engineer with 5 years of experience. Started from absolute zero with nothing but HTML.
 
-My journey started from Frontend, but throughout the years I've come to realize that I love:
+Throughout the years I've come to realize that I love:
 
 - Learning and explaining what happens **behind the scenes**,
 - Building software that hides complexities from **other engineers** by providing simple interfaces.
 
 This passion - _implicitly_ - has put me to a path that goes from **dealing with clients** to **dealing with servers and infrastructure**.
 
-Thus, I've been investing my time into learning more about servers since Sep 2022 and server infrastructure since Jan 2024.
+Thus, I've been investing my time on learning more about servers since Sep 2022 and server infrastructure since Jan 2024.
 I find great joy in learning:
 
 - How everything is connected,
 - What we can automate,
 - How we can secure and observe our overall infrastructure.
 
-This website is a proof of that.
-I built this because I was wondering how I can use a domain name I have and it's a cool idea to have a personal space on the Internet.
+This website is proof of the points above.
+I built this because I was wondering how I could use a domain name I have, and it's a cool idea to have a personal space on the Internet.
 That's it.
 
-Ok, not going to drag this so, last words:
+Ok, not going to drag this, so last words:
 
-Do all of above mean that I'm a perfect engineer? Nah, not in the slightest.
+Does all of the above mean that I'm a perfect engineer? Nah, not in the slightest.
 
 But one thing for sure - I'm having a hell of a fun time on this journey, and now I have a personal place where I can share my perspective.
 
-So f\*cking wonderful. I'll see you around.
+So wonderful. I'll see you around.

--- a/content/posts/hello-world.md
+++ b/content/posts/hello-world.md
@@ -1,6 +1,6 @@
 ---
 date: "2024-11-30T23:27:31+03:00"
-draft: true
+draft: false
 title: "Hello, World!"
 summary: "First, an introduction."
 ---

--- a/content/projects/dotfiles.md
+++ b/content/projects/dotfiles.md
@@ -1,6 +1,6 @@
 ---
 date: "2024-12-02T16:55:15+03:00"
-draft: true
+draft: false
 title: "Dotfiles"
 summary: "Local environment configuration. Powered by Ansible."
 ---
@@ -8,14 +8,14 @@ summary: "Local environment configuration. Powered by Ansible."
 Imagine this:
 
 You have your personal workstation and have been using it extensively for a couple of years.
-As a result, you have done numerous changes on that workstation:
+As a result, you have made numerous changes to that workstation:
 
 - Installed a lot of tools,
 - Configured them for your liking,
 - Fixed issues through hard work, frustration and sweat.
 
 Unfortunately, the time has come and you have to change it.
-But, that also means doing all the hardwork again to make it same like the previous one.
+But, that also means doing all the hard work again to make it the same as the previous one.
 
 If you wonder whether there is a way to _not_ do it all over again, yes, there is:
 
@@ -94,7 +94,7 @@ So basically, the idea is to:
 
 ## Why Is It Called "Dotfiles"?
 
-Normally, the configuration files and directories usually start with a `.` (dot) in Unix world such as `.bashrc` or `.ssh`.
+Normally, the configuration files and directories usually start with a `.` (dot) in the Unix world, such as `.bashrc` or `.ssh`.
 These files are also hidden.
 
 Since our goal is to store our configuration files which represent our unique local environment, the directory that holds these files is called **dotfiles** as a convention.
@@ -102,14 +102,14 @@ Since our goal is to store our configuration files which represent our unique lo
 ## The Implementation
 
 There are different ways of executing this idea.
-Essentially, all of them does more or less the same thing with the example case above.
+Essentially, all of them do more or less the same thing with the example case above.
 
 I went with **Ansible** as my weapon of choice because **dotfiles** is essentially a **configuration management project**.
-The main thing that differs from actual configuration management is that **the managed host is my own local host instead of a fleet of servers**.
+The main thing that differs from the actual configuration management is that **the managed host is my own local host instead of a fleet of servers**.
 
 Since managing one host is a lot easier than managing a thousand, I thought this is a perfect opportunity to get my hands dirty with Ansible.
 
-Also, we engineers just love storing everything as code. So in this sense this project is again - a perfect opportunity.
+Also, we engineers just love storing everything as code. So, in this sense, this project is again a perfect opportunity.
 
 So, the implementation consists of:
 
@@ -119,14 +119,16 @@ So, the implementation consists of:
 
 ## Last Words
 
-I'll be blunt in here, I would highly encourage anyone reading this to just jump right in and create their own dotfiles instead of just installing mine and call it a day.
-These configurations are what work for me and my own taste, you will probably disagree with most of the settings.
+I'll be blunt here, I would highly encourage anyone reading this to just jump right in and create their own dotfiles instead of just installing mine and calling it a day.
+These configurations are what work for me and my own taste.
+You will probably disagree with most of the settings.
 
 I believe everyone should find their own unique local environment configuration, and then slowly create their dotfiles.
 
-You can reference this project, I believe it can be a good starting point especially the installation parts with Ansible.
+You can use this project as a reference. I believe it can be a good starting point especially the installation parts with Ansible.
 
-This does not mean that everything here is absolutely perfect, as I said before this was just an opportunity for me to gain experience in Ansible and have fun while doing so.
+This does not mean that everything here is absolutely perfect.
+As I said before, this was just an opportunity for me to gain experience in Ansible and have fun while doing so.
 
 ---
 

--- a/content/projects/local-ci.md
+++ b/content/projects/local-ci.md
@@ -1,6 +1,6 @@
 ---
 date: "2024-12-03T11:37:25+03:00"
-draft: true
+draft: false
 title: "Local CI"
 summary: "Test your Jenkins pipelines locally."
 ---
@@ -31,7 +31,7 @@ My choices were quite straightforward:
 
 The service itself is really simple and the type of service (API, serverless, scheduler, etc.) doesn't matter that much.
 It just needs to have one test and a feature to be tested.
-So for the language, I choose **Golang**:
+So, for the language, I choose **Golang**:
 
 - It's really fun to play, I don't know why.
 - It's pretty dead simple to get it up and running, you just have an entrypoint and a module state and that's it, which is perfect for this project.
@@ -40,7 +40,7 @@ So for the language, I choose **Golang**:
 For the pipeline, my weapon of choice is **Jenkins**:
 
 - It is by far the most commonly used tool in the industry, we can't deny it.
-- I already actively use Github Actions in where I work, so I wanted to try something else to add a little bit more challenge.
+- I already actively use Github Actions at where I work, so I wanted to try something else to add a little bit more challenge.
 
 ## More About the "Goal"
 
@@ -51,7 +51,7 @@ Normally, a pipeline can be quite complex based on the actual need, so in order 
 - It is forbidden to install any language runtime on the Jenkins agent other than Java. The agent should stay as clean as possible.
 - The pipeline should spin up **ephemeral containers** to execute the CI steps, and then remove them when there is no error.
 - If there is an error, it should be visible to the output and developers should be able to exec into the build container to troubleshoot the issue.
-- **Any container image** can be used by the actual pipeline.
+- **Any container image** can be used by the pipeline.
 
 ---
 

--- a/content/projects/ping.md
+++ b/content/projects/ping.md
@@ -1,6 +1,6 @@
 ---
 date: "2024-12-02T22:47:58+03:00"
-draft: true
+draft: false
 title: "Ping"
 summary: "An analysis of one of the most used tools in TCP/IP."
 ---
@@ -10,7 +10,7 @@ If our desire is to become better at managing server infrastructure, we can't ig
 However, in today's world, we use lots of abstractions to build software.
 When it comes to networking, there is this thing called a _cloud provider_ that lets people rent their own private space on the Internet. Basically, you run _your_ software on _their_ infrastructure.
 
-Whilst we can appreciate the abstractions that make our lives easier, I believe we also should have a fairly high level idea of what happens under the hood, especially when it comes to Networking.
+Whilst we can appreciate the abstractions that make our lives easier, I believe we also should have a fairly high level idea of what happens under the hood, especially when it comes to networking.
 
 So this project is my take on explaining that _high level_ picture through one of the most frequently used tools.
 
@@ -29,11 +29,11 @@ I didn't want to duplicate the information to make this post longer and prettier
 
 However, I do want to say a couple of things:
 
-- The notes provided in the repository are just my understanding of several Networking concepts.
+- The notes provided in the repository are just my understanding of several networking concepts.
   There may be some misunderstandings and if that is the case, I would really like to have a feedback from you.
 
-- There were times where I had to explain a specific concept briefly to not steer too much away from the main topic.
-  Therefore the concepts that are explained in this study are actually much more deep than what they appear to be.
+- There were times when I had to explain a specific concept briefly to not steer too much away from the main topic.
+  Therefore, the concepts that are explained in this study are actually much deeper than what they appear to be.
 
 - No AI was harmed during the process.
 

--- a/content/projects/tempgen-nvim.md
+++ b/content/projects/tempgen-nvim.md
@@ -1,13 +1,13 @@
 ---
 date: "2024-12-02T15:17:28+03:00"
-draft: true
+draft: false
 title: "tempgen.nvim"
 summary: "Bootstrap your file the way you want."
 ---
 
-My favorite aspect of Vim/Neovim is the fact that you can take the full advantage of the shell itself, and create little scripts that enhance your own development workflow.
+My favorite aspect of Vim/Neovim is the fact that you can take full advantage of the shell itself, and create little scripts that enhance your own development workflow.
 
-If you can't think of any example, allow me to show you one.
+If you can't think of any examples, allow me to show you one.
 
 Enter `tempgen.nvim`.
 
@@ -48,7 +48,7 @@ Also, if you find yourself updating 3rd party CLI generated files a little bit e
 
 ### Project Code
 
-This one is a little bit stretch, but still possible.
+This one is a little bit of stretch, but still possible.
 
 If you discover a nice structure and want to use it in your future projects, automate it away!
 
@@ -59,9 +59,9 @@ If you discover a nice structure and want to use it in your future projects, aut
 **Long answer**: I implemented this project because:
 
 - My needs were pretty simple,
-- I wanted to dive into developing a Neovim plugin instead of consuming another one to see how the experience is.
+- I wanted to dive into developing a Neovim plugin instead of using another one to see how the experience is.
 
-I acknowledge the fact that the tool is not fully fledged out and there is a nice room for improvement.
+I acknowledge the fact that the tool is not fully fledged and there is a nice room for improvement.
 That is why I added the [TODO section](https://github.com/acikgozb/tempgen.nvim?tab=readme-ov-file#todo) to the repository.
 
 ---


### PR DESCRIPTION
Now that the infrastructure is more or less ready, I wanted to have no blockers from the actual content -> in this case the `draft` field that hides the content and the pesky typos.

Therefore I removed the draft status from all posts and applied a small profanity filter :))