### PR TITLE
Use default AWS_PROFILE for CD pipeline

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
           aws-region: "${{ env.AWS_REGION }}"
           role-to-assume: "${{ secrets.AWS_OIDC_ROLE_ARN }}"
-          role-session-name: "${{ env.APP_NAME }}-cd-session-${{ github.build_number }}"
+          role-session-name: "${{ env.APP_NAME }}-aws-session-${{ github.run_id }}"
 
       - name: Set environment
         run: |

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -26,8 +26,8 @@ terraform {
 }
 
 provider "aws" {
-  # profile = $AWS_PROFILE
   # region = $AWS_REGION
+  # profile = $AWS_PROFILE -> for local development.
 
   default_tags {
     tags = local.default_tags

--- a/terraform/scripts/exec
+++ b/terraform/scripts/exec
@@ -4,6 +4,8 @@ set -euo pipefail
 
 function environment {
     APP_NAME="acikgozb-dev"
+
+    AWS_PROFILE="${AWS_PROFILE:-default}"
     AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text --profile "$AWS_PROFILE")
 
     TF_BACKEND_STATE_BUCKET="terraform-$AWS_ACCOUNT_ID"    


### PR DESCRIPTION
The CD pipeline authorizes with OIDC, which does not have the concept of a "user profile".

"configure-aws-credentials" exports `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN`.

Therefore, the helper exec script is updated to use the default value for `AWS_PROFILE` if it does not exist, which will make AWS to go through its credential chain and pick up the required access key and secret access key.

The existence of `AWS_PROFILE` means that the script is executed locally. Therefore a small comment is added to Terraform AWS provider to notify the user.