### PR TITLE
Add hashicorp/setup-terraform to pipeline with a fixed version

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -63,6 +63,11 @@ jobs:
             echo "${env%:*}=${env#*:}" >> "$GITHUB_ENV"; \
           done
 
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.9.8
+
       - name: Initialize Terraform
         run: |
           ./scripts/exec init


### PR DESCRIPTION
The version is fixed to 1.9.8 for now, since that is the version I'm currently using locally.