### PR TITLE
Move redirect-worker artifact generation under package.json

### DIFF
--- a/terraform/scripts/exec
+++ b/terraform/scripts/exec
@@ -27,7 +27,7 @@ function generate_artifacts {
     cd ./scripts/redirect-worker
 
     npm ci
-    wrangler deploy --outdir ./out --config ./wrangler.toml --dry-run
+    npm run generate-artifact
 
     REDIRECT_WORKER_PATH="./scripts/redirect-worker/out/index.js"
 

--- a/terraform/scripts/redirect-worker/package.json
+++ b/terraform/scripts/redirect-worker/package.json
@@ -2,6 +2,9 @@
   "name": "redirect-worker",
   "version": "1.0.0",
   "private": true,
+  "scripts": {
+    "generate-artifact": "./node_modules/wrangler/bin/wrangler.js deploy --outdir ./out --config ./wrangler.toml --dry-run"
+  },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241205.0",
     "typescript": "^5.5.2",


### PR DESCRIPTION
Since `wrangler` is not installed globally (the recommended way by Cloudflare), the binary path must be manually entered.

The binary path depends on the installed version of `wrangler`, which is specified under the Worker's `package.json`.

Therefore, the artifact generation command is moved under `package.json` to easily see how `wrangler` is used, so that in the future if binary path changes then only the Worker itself will be changed.