### PR TITLE
Update IaC scripts according to TF plan errors

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -78,4 +78,4 @@ jobs:
 
       - name: Apply Terraform plan
         run: |
-          ./scripts/exec apply
+          ./scripts/exec apply > /dev/null

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -80,6 +80,11 @@ data "aws_iam_policy_document" "cf_only_ingress" {
   statement {
     actions = ["s3:GetObject"]
 
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
     resources = [aws_s3_bucket.acikgozb_dev.arn]
 
     condition {
@@ -189,8 +194,6 @@ resource "cloudflare_record" "bucket_cname" {
   content = aws_s3_bucket.acikgozb_dev.bucket_regional_domain_name
   proxied = true
   comment = "CNAME for site bucket."
-
-  tags = [for k, v in local.default_tags : "${k}, ${v}"]
 }
 
 resource "cloudflare_record" "www_cname" {
@@ -200,6 +203,4 @@ resource "cloudflare_record" "www_cname" {
   content = local.root_zone_name
   proxied = true
   comment = "CNAME for www."
-
-  tags = [for k, v in local.default_tags : "${k}, ${v}"]
 }


### PR DESCRIPTION
- Tags for Cloudflare resources are removed, apparently no tags are allowed on free plan :)
- Missing `Principal` field is added to S3 bucket policy.
- The test resources that cause drift are removed from Cloudflare via Dashboard.
- The `terraform apply` stdout is silenced since it contains sensitive information. Normally this is not necessary since the resource creation would live on a private repository, but since this repo is intentionally public I silenced the output instead.