### PR TITLE
Cleanup the frontend artifact after each workflow run

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -16,8 +16,11 @@ env:
   FRONTEND_ARTIFACT_PATH: "public"
 
 jobs:
-  create-frontend-assets:
+  create-frontend-artifact:
     runs-on: ubuntu-24.04
+
+    outputs:
+      artifact-id: "${{ steps.upload-frontend-artifact.outputs.artifact-id }}"
 
     steps:
       - name: Checkout
@@ -30,12 +33,13 @@ jobs:
         with:
           hugo-version: 0.139.3
 
-      - name: Create frontend artifact
+      - name: Create the frontend artifact
         shell: bash
         run: |
           hugo build --destination "$FRONTEND_ARTIFACT_PATH" --minify
 
-      - name: Upload frontend artifact
+      - name: Upload the frontend artifact
+        id: upload-frontend-artifact
         uses: actions/upload-artifact@v4
         with:
           name: frontend-artifact
@@ -43,7 +47,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-24.04
-    needs: create-frontend-assets
+    needs: create-frontend-artifact
 
     defaults:
       run:
@@ -61,7 +65,7 @@ jobs:
           role-to-assume: "${{ secrets.AWS_OIDC_ROLE_ARN }}"
           role-session-name: "${{ env.APP_NAME }}-aws-session-${{ github.run_id }}"
 
-      - name: Set environment
+      - name: Set the environment
         run: |
           read -r -a tf_env < <(./scripts/exec environment); \
           for env in ${tf_env[@]}; \
@@ -84,14 +88,21 @@ jobs:
           name: frontend-artifact
           path: "${{ env.FRONTEND_ARTIFACT_PATH}}"
 
-      - name: Debug the workdir
+      - name: Create Terraform plan
         run: |
-          ls -R
+          ./scripts/exec plan
+        #
+        # - name: Apply Terraform plan
+        #   run: |
+        #     ./scripts/exec apply > /dev/null
+      - name: Cleanup the frontend artifact
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.actions.deleteArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: ${{ needs.create-frontend-artifact.outputs.artifact-id }}
+            })
 
-    # - name: Create Terraform plan
-    #   run: |
-    #     ./scripts/exec plan
-    #
-    # - name: Apply Terraform plan
-    #   run: |
-    #     ./scripts/exec apply > /dev/null

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -40,7 +40,7 @@ provider "cloudflare" {
 
 locals {
   root_zone_name         = "acikgozb.dev"
-  frontend_artifact_path = "${path.module}/${var.frontend_artifact_path}"
+  frontend_artifact_path = "${path.module}/../${var.frontend_artifact_path}"
 
   default_tags = {
     Application = var.app_name


### PR DESCRIPTION
Unfortunately, there is not a default way to remove the generated artifacts in a workflow run.

Also, with `actions/upload-artifact@v4` it is not possible to upload an artifact with the same name.

Therefore, a cleanup step is added to query the Github API and remove the artifact manually.

Also, the artifact path in the main IaC script is updated after the debugging session.

For the remove script itself, see https://github.com/actions/upload-artifact/issues/550#issuecomment-2059919616