### PR TITLE
Add public access block for S3 bucket

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -62,6 +62,15 @@ resource "aws_s3_bucket" "acikgozb_dev" {
   }
 }
 
+resource "aws_s3_bucket_public_access_block" "acikgozb_dev" {
+  bucket = aws_s3_bucket.acikgozb_dev.id
+
+  block_public_acls       = true
+  ignore_public_acls      = true
+  block_public_policy     = false
+  restrict_public_buckets = false
+}
+
 resource "aws_s3_object" "acikgozb_dev_content" {
   for_each = fileset("${local.frontend_artifact_path}/", "**")
 

--- a/terraform/scripts/redirect-worker/package.json
+++ b/terraform/scripts/redirect-worker/package.json
@@ -1,5 +1,6 @@
 {
   "name": "redirect-worker",
+  "type": "module",
   "version": "1.0.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
The public access block for the S3 bucket is turned off.

This may sound anti-practice, but the access is controlled with the policy which only allows valid Cloudflare IPs to get the objects.

Having the public access block turned on also prevents other resources (e.g Cloudflare's Cloud Connector) to see the bucket, therefore fail during the provision step.

Also, in order to allow using "import" statements inside the bundled JS script, the type field is updated to be 'module'.